### PR TITLE
Add table creation SQL for DATA_CONTRACTS

### DIFF
--- a/sql/create_data_contracts.sql
+++ b/sql/create_data_contracts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS DATA_CONTRACTS (
+    object_name STRING NOT NULL,
+    object_type STRING NOT NULL,
+    expected_schema VARIANT,
+    expected_dependencies ARRAY,
+    target_lag STRING,
+    enforced BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    updated_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+

--- a/sql/insert_data_contracts.sql
+++ b/sql/insert_data_contracts.sql
@@ -1,0 +1,16 @@
+INSERT INTO DATA_CONTRACTS (
+  object_name,
+  object_type,
+  expected_schema,
+  expected_dependencies,
+  target_lag,
+  enforced
+)
+VALUES (
+  'MY_DB.MY_SCHEMA.MY_DYNAMIC_TABLE',
+  'DYNAMIC_TABLE',
+  PARSE_JSON('[{"name": "id", "type": "NUMBER"}, {"name": "name", "type": "STRING"}, {"name": "created_at", "type": "TIMESTAMP_LTZ"}]'),
+  ARRAY_CONSTRUCT('MY_DB.MY_SCHEMA.SOURCE_TABLE'),
+  '5 minutes',
+  TRUE
+);

--- a/sql/merge_data_contracts.sql
+++ b/sql/merge_data_contracts.sql
@@ -1,0 +1,23 @@
+MERGE INTO DATA_CONTRACTS AS target
+USING DATA_CONTRACTS_STAGING AS src
+  ON target.object_name = src.object_name
+WHEN MATCHED THEN
+  UPDATE SET
+    target.expected_schema = src.expected_schema,
+    target.expected_dependencies = src.expected_dependencies,
+    target.target_lag = src.target_lag,
+    target.updated_at = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN
+  INSERT (
+    object_name,
+    expected_schema,
+    expected_dependencies,
+    target_lag,
+    updated_at
+  ) VALUES (
+    src.object_name,
+    src.expected_schema,
+    src.expected_dependencies,
+    src.target_lag,
+    CURRENT_TIMESTAMP()
+  );


### PR DESCRIPTION
## Summary
- add SQL file to create the `DATA_CONTRACTS` table
- add MERGE script for upserting data contracts
- add sample insertion script for a dynamic table contract

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686033cbb644832ca8d634fea773a49c