### PR TITLE
Add table creation script for DAG contract results

### DIFF
--- a/sql/check_dependency_contracts.sql
+++ b/sql/check_dependency_contracts.sql
@@ -1,0 +1,87 @@
+-- Create table to store dependency contract results
+CREATE TABLE IF NOT EXISTS DAG_CONTRACT_RESULTS (
+    object_name STRING,
+    is_compliant BOOLEAN,
+    missing_dependencies ARRAY,
+    unexpected_dependencies ARRAY,
+    last_checked TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Stored procedure to check dependency contracts
+CREATE OR REPLACE PROCEDURE CHECK_DEPENDENCY_CONTRACTS()
+RETURNS TABLE (
+    object_name STRING,
+    is_compliant BOOLEAN,
+    missing_dependencies ARRAY,
+    unexpected_dependencies ARRAY,
+    last_checked TIMESTAMP_LTZ
+)
+LANGUAGE JAVASCRIPT
+AS
+$$
+var results = [];
+var contracts_stmt = snowflake.createStatement({sqlText:
+    `SELECT object_name, expected_dependencies
+       FROM DATA_CONTRACTS
+      WHERE enforced = TRUE`});
+var contracts_rs = contracts_stmt.execute();
+while (contracts_rs.next()) {
+    var objName = contracts_rs.getColumnValue(1);
+    var expectedDeps = contracts_rs.getColumnValue(2);
+    if (typeof expectedDeps === 'string') {
+        expectedDeps = JSON.parse(expectedDeps);
+    }
+    if (!Array.isArray(expectedDeps)) {
+        expectedDeps = [];
+    }
+
+    var parts = objName.split('.');
+    var db = parts[0];
+    var sch = parts[1];
+    var name = parts[2];
+
+    var deps_stmt = snowflake.createStatement({sqlText:
+        `SELECT DISTINCT referenced_object_database || '.' || referenced_object_schema || '.' || referenced_object_name
+           FROM SNOWFLAKE.ACCOUNT_USAGE.OBJECT_DEPENDENCIES
+          WHERE object_database = ? AND object_schema = ? AND object_name = ?`,
+        binds: [db, sch, name]});
+    var deps_rs = deps_stmt.execute();
+    var actualDeps = [];
+    while (deps_rs.next()) {
+        actualDeps.push(deps_rs.getColumnValue(1));
+    }
+
+    var missing = [];
+    expectedDeps.forEach(function(d) {
+        if (actualDeps.indexOf(d) === -1) {
+            missing.push(d);
+        }
+    });
+
+    var unexpected = [];
+    actualDeps.forEach(function(d) {
+        if (expectedDeps.indexOf(d) === -1) {
+            unexpected.push(d);
+        }
+    });
+
+    var compliant = (missing.length === 0 && unexpected.length === 0);
+
+    snowflake.createStatement({
+        sqlText: `INSERT INTO DAG_CONTRACT_RESULTS(
+                    object_name, is_compliant, missing_dependencies,
+                    unexpected_dependencies, last_checked)
+                  SELECT ?, ?, PARSE_JSON(?), PARSE_JSON(?), CURRENT_TIMESTAMP()`,
+        binds: [objName, compliant, JSON.stringify(missing), JSON.stringify(unexpected)]
+    }).execute();
+
+    results.push({
+        object_name: objName,
+        is_compliant: compliant,
+        missing_dependencies: missing,
+        unexpected_dependencies: unexpected,
+        last_checked: new Date()
+    });
+}
+return results;
+$$;

--- a/sql/check_schema_drift.sql
+++ b/sql/check_schema_drift.sql
@@ -1,0 +1,92 @@
+-- Create table to store schema drift results
+CREATE TABLE IF NOT EXISTS SCHEMA_DRIFT_RESULTS (
+    object_name STRING,
+    is_compliant BOOLEAN,
+    missing_columns ARRAY,
+    extra_columns ARRAY,
+    mismatched_types ARRAY,
+    last_checked TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Stored procedure to check schema drift for enforced data contracts
+CREATE OR REPLACE PROCEDURE CHECK_SCHEMA_DRIFT()
+RETURNS TABLE (
+    object_name STRING,
+    is_compliant BOOLEAN,
+    missing_columns ARRAY,
+    extra_columns ARRAY,
+    mismatched_types ARRAY,
+    last_checked TIMESTAMP_LTZ
+)
+LANGUAGE JAVASCRIPT
+AS
+$$
+var results = [];
+var contract_stmt = snowflake.createStatement({sqlText:
+    `SELECT object_name, expected_schema
+       FROM DATA_CONTRACTS
+      WHERE enforced = TRUE`});
+var contract_rs = contract_stmt.execute();
+while (contract_rs.next()) {
+    var objName = contract_rs.getColumnValue(1);
+    var expectedSchema = JSON.parse(contract_rs.getColumnValue(2));
+
+    var tokens = objName.split('.');
+    var db = tokens[0];
+    var sch = tokens[1];
+    var table = tokens[2];
+
+    var actual_stmt = snowflake.createStatement({sqlText:
+        `SELECT column_name, data_type
+           FROM "${db}".information_schema.columns
+          WHERE table_schema = '${sch}' AND table_name = '${table}'`});
+    var actual_rs = actual_stmt.execute();
+    var actualMap = {};
+    while (actual_rs.next()) {
+        actualMap[actual_rs.getColumnValue(1).toUpperCase()] = actual_rs.getColumnValue(2).toUpperCase();
+    }
+
+    var expectedMap = {};
+    for (var i = 0; i < expectedSchema.length; i++) {
+        var col = expectedSchema[i];
+        expectedMap[col.name.toUpperCase()] = col.type.toUpperCase();
+    }
+
+    var missing = [];
+    var mismatched = [];
+    for (var key in expectedMap) {
+        if (!(key in actualMap)) {
+            missing.push(key);
+        } else if (expectedMap[key] !== actualMap[key]) {
+            mismatched.push(key);
+        }
+    }
+
+    var extra = [];
+    for (var key in actualMap) {
+        if (!(key in expectedMap)) {
+            extra.push(key);
+        }
+    }
+
+    var compliant = (missing.length === 0 && extra.length === 0 && mismatched.length === 0);
+
+    snowflake.createStatement({
+        sqlText: `INSERT INTO SCHEMA_DRIFT_RESULTS(
+                    object_name, is_compliant, missing_columns,
+                    extra_columns, mismatched_types, last_checked)
+                  SELECT ?, ?, PARSE_JSON(?), PARSE_JSON(?), PARSE_JSON(?), CURRENT_TIMESTAMP()`,
+        binds: [objName, compliant, JSON.stringify(missing), JSON.stringify(extra), JSON.stringify(mismatched)]
+    }).execute();
+
+    results.push({
+        object_name: objName,
+        is_compliant: compliant,
+        missing_columns: missing,
+        extra_columns: extra,
+        mismatched_types: mismatched,
+        last_checked: new Date()
+    });
+}
+return results;
+$$;

--- a/sql/create_dag_contract_results.sql
+++ b/sql/create_dag_contract_results.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS DAG_CONTRACT_RESULTS (
+  object_name STRING,
+  is_compliant BOOLEAN,
+  missing_dependencies ARRAY,
+  unexpected_dependencies ARRAY,
+  last_checked TIMESTAMP_LTZ DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/sql/create_data_contracts.sql
+++ b/sql/create_data_contracts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS DATA_CONTRACTS (
+    object_name STRING NOT NULL,
+    object_type STRING NOT NULL,
+    expected_schema VARIANT,
+    expected_dependencies ARRAY,
+    target_lag STRING,
+    enforced BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    updated_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+

--- a/sql/insert_data_contracts.sql
+++ b/sql/insert_data_contracts.sql
@@ -1,0 +1,16 @@
+INSERT INTO DATA_CONTRACTS (
+  object_name,
+  object_type,
+  expected_schema,
+  expected_dependencies,
+  target_lag,
+  enforced
+)
+VALUES (
+  'MY_DB.MY_SCHEMA.MY_DYNAMIC_TABLE',
+  'DYNAMIC_TABLE',
+  PARSE_JSON('[{"name": "id", "type": "NUMBER"}, {"name": "name", "type": "STRING"}, {"name": "created_at", "type": "TIMESTAMP_LTZ"}]'),
+  ARRAY_CONSTRUCT('MY_DB.MY_SCHEMA.SOURCE_TABLE'),
+  '5 minutes',
+  TRUE
+);

--- a/sql/merge_data_contracts.sql
+++ b/sql/merge_data_contracts.sql
@@ -1,0 +1,23 @@
+MERGE INTO DATA_CONTRACTS AS target
+USING DATA_CONTRACTS_STAGING AS src
+  ON target.object_name = src.object_name
+WHEN MATCHED THEN
+  UPDATE SET
+    target.expected_schema = src.expected_schema,
+    target.expected_dependencies = src.expected_dependencies,
+    target.target_lag = src.target_lag,
+    target.updated_at = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN
+  INSERT (
+    object_name,
+    expected_schema,
+    expected_dependencies,
+    target_lag,
+    updated_at
+  ) VALUES (
+    src.object_name,
+    src.expected_schema,
+    src.expected_dependencies,
+    src.target_lag,
+    CURRENT_TIMESTAMP()
+  );


### PR DESCRIPTION
## Summary
- add SQL script to create `DAG_CONTRACT_RESULTS` table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686033cbb644832ca8d634fea773a49c